### PR TITLE
Changing name of database.

### DIFF
--- a/art-elephant/db/artElephant.sql
+++ b/art-elephant/db/artElephant.sql
@@ -1,5 +1,5 @@
-DROP DATABASE IF EXISTS artelephant;
-CREATE DATABASE artelephant;
+DROP DATABASE IF EXISTS elephant;
+CREATE DATABASE elephant;
 
 \c artelephant;
 


### PR DESCRIPTION
Changing name of database from "artelephant" to "elephant." Original name was too cumbersome to type correctly.