### PR TITLE
Updating connection string to 'elephant'

### DIFF
--- a/art-elephant/auth/db.js
+++ b/art-elephant/auth/db.js
@@ -1,5 +1,5 @@
 const pgp = require('pg-promise')({});
-const connectionString = 'postgres://localhost/artelephant';
+const connectionString = 'postgres://localhost/elephant';
 const db = pgp(connectionString);
 
 module.exports = db;


### PR DESCRIPTION
Changed database name to "elephant." Previous name "artelephant" was too cumbersome.