### PR TITLE
Changing route for login and new user to use email to pass as props.

### DIFF
--- a/art-elephant/client/src/components/Login/Alert.js
+++ b/art-elephant/client/src/components/Login/Alert.js
@@ -3,10 +3,19 @@ import React from 'react';
 const Alert = ({ submit, message }) => {
     return(
         <div>
-            {submit === false ? 
+            {/* {submit === false ? 
                 <div className="alert alert-danger" role="alert">
                     {message}
                 </div> : ""
+            } */}
+            {submit ? 
+                <div className="alert alert-success" role="alert">
+                    {message}
+                </div> : (submit === false ? 
+                    <div className="alert alert-danger" role="alert">
+                        {message}
+                    </div> : ""
+                )
             }
         </div>
     )

--- a/art-elephant/client/src/components/Login/NewUser.js
+++ b/art-elephant/client/src/components/Login/NewUser.js
@@ -67,7 +67,7 @@ class NewUser extends Component {
 
     render() {
         const { first_name, last_name, email, password, message, submit } = this.state;
-        console.log("submit:", submit)
+        // console.log("submit:", submit)
         return (
             <div className='content'>
                 <h1>Create an Account</h1>
@@ -108,9 +108,11 @@ class NewUser extends Component {
                 </form>
 
                 <Route path="/new-user" render={ () => (
-                    submit ? <Redirect to="/my-account" /> 
+                    submit ? <Redirect to={{pathname: "/my-account", state: {email: email}}} /> 
                     : <Alert submit={submit} message={message} /> 
                 )} />
+
+                {/* <Alert submit={submit} message={message} />  */}
 
             </div>
         )

--- a/art-elephant/client/src/components/MyAccount/MyAccount.js
+++ b/art-elephant/client/src/components/MyAccount/MyAccount.js
@@ -8,14 +8,14 @@ class MyAccount extends Component {
     constructor(props){
         super(props);
         this.state = {
-            user_id: this.props.user,
+            email: this.props.user,
             user: null
         };
     }
 
     getUser = () => {
-        const { user_id } = this.state
-        axios.post(`/users/${user_id}`)
+        const { email } = this.state
+        axios.post(`/users/${email}`)
             .then( res => {
                 let user = res.data.single_user[0];
                 this.setState({
@@ -52,7 +52,7 @@ class MyAccount extends Component {
             return(
                 <div className='content'>
                     <h1>My Account</h1>
-                    <p>user_id:{user.id ? user.id : " no user"}</p>
+                    <p>email:{user.id ? user.id : " no user"}</p>
 
                     <div className="logout">
                         <Link className="btn btn-outline-dark" 

--- a/art-elephant/db/user-queries.js
+++ b/art-elephant/db/user-queries.js
@@ -29,14 +29,14 @@ const loginUser = (req, res, next) => {
                     res.status(200)
                         .json({
                             status: 'success',
-                            user: data[0].id,
+                            user: data[0].email,
                             message: 'Logged in'
                         });
                 } else if (!compare) {
                     res.status(204)
                         .json({
                             status: 'error',
-                            user: data[0].id,
+                            user: data[0].email,
                             message: 'Incorrect password'
                         });
                 }
@@ -53,7 +53,8 @@ const loginUser = (req, res, next) => {
 };
 
 const getSingleUser = (req, res, next) => {
-    db.any('SELECT id, first_name, last_name, email FROM users WHERE id=${user_id}', req.params)
+    console.log("get params:", req.params);
+    db.any('SELECT id, first_name, last_name, email FROM users WHERE email=${email}', req.params)
         .then(data => {
             res.status(200)
             .send({

--- a/art-elephant/routes/users.js
+++ b/art-elephant/routes/users.js
@@ -8,7 +8,7 @@ const db = require('../db/user-queries');
 
 router.get('/', db.getUsers);
 router.post('/new', db.registerUser);
-router.post('/:user_id', db.getSingleUser);
+router.post('/:email', db.getSingleUser);
 router.post('/', db.loginUser);
 router.put('/update-pw', db.updatePassword);
 router.put('/update', db.updateUser);


### PR DESCRIPTION
Previously, I had used user id to pass as props into MyAccount.js. This would not be suitable for a new user, who doesn't have a user id yet. MyAccount.js depends on a user id to query the database. 

I prefer to use user id, but I don't have a solution for new user yet. 