### PR TITLE
Removing react-geocode from front-end dependencies.

### DIFF
--- a/art-elephant/client/package.json
+++ b/art-elephant/client/package.json
@@ -11,7 +11,6 @@
     "react": "^16.3.2",
     "react-bootstrap": "^0.32.1",
     "react-dom": "^16.3.2",
-    "react-geocode": "0.0.7",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.1.4"
   },


### PR DESCRIPTION
The app no longer uses the npm package React-Geocode. I has been replaced with Google Geocoding API endpoint.