### PR TITLE
Fixing new user redirect.

### DIFF
--- a/art-elephant/client/src/components/Login/NewUser.js
+++ b/art-elephant/client/src/components/Login/NewUser.js
@@ -92,7 +92,7 @@ class NewUser extends Component {
                 {/* Successful new user registration will redirect the user to the My Account page. 
                     If an email is already on file, new user will see an alert that says email is taken.*/}
                 <Route path="/new-user" render={ () => (
-                    submit ? <Redirect to={{pathname: "/my-account", state: {email: email}}} /> 
+                    submit ? <Redirect to={{pathname: "/my-account", state: {user: email}}} /> 
                     : <Alert submit={submit} message={message} /> 
                 )} />
 


### PR DESCRIPTION
The redirect state was incorrect. The prop passed into the redirect state should be "user." This is to match the prop passed from the Login component. My Account is used by both Login and New User components. My Account takes in the prop user.

Successful registration will redirect to My Account and update navbar link.