### PR TITLE
Setting user to null on logout

### DIFF
--- a/art-elephant/client/src/App.js
+++ b/art-elephant/client/src/App.js
@@ -79,7 +79,7 @@ class App extends Component {
   };
 
   handleLogout = () => {
-    this.setState({ email: "", password: "", message: "", submit: null });
+    this.setState({ user: null, email: "", password: "", message: "", submit: null });
   }
 
   renderLogin = () => {


### PR DESCRIPTION
Previously, user email was still stored in state on logout.